### PR TITLE
Fix getting started errors and publish templates package

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -73,6 +73,9 @@ jobs:
     - name: Pack NuGet package
       run: dotnet pack CheapAvaloniaBlazor.csproj --configuration ${{ env.CONFIGURATION }} --no-build --output ./nupkgs
 
+    - name: Pack template package
+      run: dotnet pack templates/CheapAvaloniaBlazor.Templates.csproj --configuration ${{ env.CONFIGURATION }} --output ./nupkgs
+
     - name: Upload NuGet package
       uses: actions/upload-artifact@v4
       with:

--- a/CheapAvaloniaBlazor.csproj
+++ b/CheapAvaloniaBlazor.csproj
@@ -8,7 +8,7 @@
 
     <!-- Package Information -->
     <PackageId>CheapAvaloniaBlazor</PackageId>
-    <Version>3.1.1</Version>
+    <Version>3.1.2</Version>
     <Authors>CheapNud</Authors>
     <Company>CheapLudes</Company>
     <Description>Stable Blazor desktop framework with professional splash screen, embedded JavaScript bridge, and clean file management</Description>
@@ -17,7 +17,7 @@
     <PackageTags>blazor;avalonia;photino;desktop;mudblazor;cross-platform;webview;splash-screen</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Version 3.1.1 - New ICookieService for WebView cookie extraction (stub returning empty until Photino.NET exposes a cookie manager). Updated dependencies: Avalonia 12.0.2, MudBlazor 9.4.0, Tmds.DBus.Protocol 0.93.0. DBus hotkey backend refactored to proper async with ConfigureAwait(false), wrapped in Task.Run at the sync interface boundary.</PackageReleaseNotes>
+    <PackageReleaseNotes>Version 3.1.2 - CheapAvaloniaBlazor.Templates is now published to NuGet (dotnet new cheapblazor / cheapblazor-full). Fixed getting started guide: missing usings and namespace imports, stale package versions. Updated dependencies: Avalonia 12.0.4, MudBlazor 9.5.0, Tmds.DBus.Protocol 0.94.1.</PackageReleaseNotes>
 
     <!-- Build Configuration -->
     <LangVersion>latest</LangVersion>
@@ -40,13 +40,13 @@
 
   <ItemGroup>
     <!-- Core Dependencies -->
-    <PackageReference Include="Avalonia" Version="12.0.2" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
-    <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <PackageReference Include="Avalonia" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageReference Include="MudBlazor" Version="9.5.0" />
     <PackageReference Include="Photino.NET" Version="4.0.16" />
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.93.0" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.94.1" />
     <!-- Framework Reference for Blazor Server (provides Components.Web, Hosting, FileProviders) -->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 

--- a/Docs/getting-started.md
+++ b/Docs/getting-started.md
@@ -58,7 +58,7 @@ Open your `.csproj` file and modify it:
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="CheapAvaloniaBlazor" Version="2.0.0" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
   </ItemGroup>
 </Project>
 ```
@@ -75,6 +75,7 @@ The `Program.cs` file is your application's entry point. This is where you confi
 Replace your `Program.cs` with:
 
 ```csharp
+using CheapAvaloniaBlazor.Extensions;
 using CheapAvaloniaBlazor.Hosting;
 
 namespace MyDesktopApp;
@@ -105,6 +106,7 @@ class Program
 
 **Why Each Part Matters:**
 
+- `using CheapAvaloniaBlazor.Extensions;` - Required for the `AddMudBlazor()` extension method
 - `[STAThread]` - Required on Windows for COM interop (file dialogs, notifications)
 - `new HostBuilder()` - Creates the application builder using ASP.NET Core's dependency injection
 - `.WithTitle()` - Sets the window title bar text
@@ -291,7 +293,11 @@ The `_Imports.razor` file provides using statements that are automatically avail
 @using MudBlazor
 @using CheapAvaloniaBlazor
 @using CheapAvaloniaBlazor.Services
+@using MyDesktopApp.Components
+@using MyDesktopApp.Shared
 ```
+
+> **Important:** The last two lines import your own project's namespaces. The folder structure determines the namespace: `MainLayout` lives in `MyDesktopApp.Shared` (Shared folder) while `Routes` lives in `MyDesktopApp.Components` (Components folder). Without these imports, `Routes.razor` cannot resolve `MainLayout` and the build fails with a confusing CS1662 error pointing at the Razor-generated code. If you named your project something other than "MyDesktopApp", adjust these namespaces accordingly.
 
 **What Each Using Does:**
 
@@ -306,6 +312,8 @@ The `_Imports.razor` file provides using statements that are automatically avail
 - `MudBlazor` - Material Design components
 - `CheapAvaloniaBlazor` - Core desktop functionality
 - `CheapAvaloniaBlazor.Services` - `IDesktopInteropService` for file dialogs, notifications, etc.
+- `MyDesktopApp.Components` - Your project's `Routes` component (referenced from `App.razor`)
+- `MyDesktopApp.Shared` - Your project's `MainLayout` component (referenced from `Routes.razor`)
 
 ### Step 8: Create Your First Page (Pages/Index.razor)
 

--- a/Docs/getting-started.md
+++ b/Docs/getting-started.md
@@ -58,7 +58,7 @@ Open your `.csproj` file and modify it:
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.2" />
   </ItemGroup>
 </Project>
 ```

--- a/Docs/installation.md
+++ b/Docs/installation.md
@@ -13,9 +13,9 @@ Before getting started, ensure your system meets these requirements.
 | Requirement | Minimum | Recommended | Status |
 |---|---|---|---|
 | **.NET Runtime** | 10.0 | Latest 10.0+ | Required |
-| **Windows** | 10 | 11 | ✅ Fully Tested |
-| **Linux** | Ubuntu 20.04+ | Ubuntu 22.04+ | ⚠️ Untested |
-| **macOS** | 10.15+ | Latest | ⚠️ Untested |
+| **Windows** | 10 | 11 | âœ… Fully Tested |
+| **Linux** | Ubuntu 20.04+ | Ubuntu 22.04+ | âš ï¸ Untested |
+| **macOS** | 10.15+ | Latest | âš ï¸ Untested |
 
 ### Development Requirements
 
@@ -121,7 +121,7 @@ Both commands should complete **without errors**. If you see errors, check the t
 #### Step 1: Create New Project
 
 1. Open **Visual Studio 2022**
-2. Click **File** → **New** → **Project**
+2. Click **File** â†’ **New** â†’ **Project**
 3. Search for **"Console App"** (.NET)
 4. Select **"Console App"** template
 5. Click **Next**
@@ -161,12 +161,12 @@ Visual Studio will:
 #### Step 5: Verify Installation
 
 After installation completes:
-1. Right-click **Project** → **Build Project**
+1. Right-click **Project** â†’ **Build Project**
 2. Check **Output** window for build success
 3. Look for message: **"Build succeeded"**
 
 **Common Issues During Installation:**
-- If NuGet fails to restore, try: **Tools** → **Options** → **NuGet Package Manager** → **Clear All NuGet Cache(s)**
+- If NuGet fails to restore, try: **Tools** â†’ **Options** â†’ **NuGet Package Manager** â†’ **Clear All NuGet Cache(s)**
 - If build fails, ensure you selected **.NET 10.0** framework in Step 3
 
 ---
@@ -220,7 +220,7 @@ Edit `MyDesktopApp.csproj` to use Razor SDK:
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="CheapAvaloniaBlazor" Version="2.0.0" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
   </ItemGroup>
 </Project>
 ```
@@ -260,10 +260,10 @@ When you run `dotnet add package CheapAvaloniaBlazor`, you get:
 
 ```
 C:\Users\...\MyDesktopApp\.nuget\packages
-├── avalonia/               (Desktop framework)
-├── mudbla zor/             (UI components)
-├── photino.net/            (WebView hosting)
-└── [dependencies]/         (Supporting packages)
+â”œâ”€â”€ avalonia/               (Desktop framework)
+â”œâ”€â”€ mudbla zor/             (UI components)
+â”œâ”€â”€ photino.net/            (WebView hosting)
+â””â”€â”€ [dependencies]/         (Supporting packages)
 ```
 
 **Total Size:** ~200-300 MB (first installation only, cached for future projects)
@@ -418,7 +418,7 @@ dotnet --version
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="CheapAvaloniaBlazor" Version="2.0.0" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
   </ItemGroup>
 </Project>
 ```
@@ -483,7 +483,7 @@ dotnet build
 
 1. Ensure **.NET 10.0 SDK is installed** (not just Runtime)
 2. Restart Visual Studio completely
-3. Go to **Tools** → **Options** → **Projects and Solutions** → **.NET Core**
+3. Go to **Tools** â†’ **Options** â†’ **Projects and Solutions** â†’ **.NET Core**
 4. Enable experimental features if disabled
 5. Close and reopen Visual Studio
 
@@ -502,7 +502,7 @@ dotnet new console -n MyDesktopApp
 **Solutions:**
 
 **Visual Studio:**
-1. Go to **Debug** → **Edit and Continue**
+1. Go to **Debug** â†’ **Edit and Continue**
 2. Enable **"Hot Reload on File Save"**
 3. Ensure project targets .NET 10.0
 4. Restart debugger
@@ -861,10 +861,10 @@ Version 2.0.0 migrates from the legacy Blazor Server pattern to the modern Blazo
 
 #### What Changed Internally
 
-- `AddServerSideBlazor()` → `AddRazorComponents().AddInteractiveServerComponents()`
-- `MapBlazorHub()` + `MapFallbackToPage()` → `MapRazorComponents<App>().AddInteractiveServerRenderMode()`
-- `blazor.server.js` → `blazor.web.js`
-- `_Host.cshtml` (Razor Page) → `App.razor` (Razor component as HTML document root)
+- `AddServerSideBlazor()` â†’ `AddRazorComponents().AddInteractiveServerComponents()`
+- `MapBlazorHub()` + `MapFallbackToPage()` â†’ `MapRazorComponents<App>().AddInteractiveServerRenderMode()`
+- `blazor.server.js` â†’ `blazor.web.js`
+- `_Host.cshtml` (Razor Page) â†’ `App.razor` (Razor component as HTML document root)
 - Razor Pages middleware removed entirely
 
 ---

--- a/Docs/installation.md
+++ b/Docs/installation.md
@@ -13,9 +13,9 @@ Before getting started, ensure your system meets these requirements.
 | Requirement | Minimum | Recommended | Status |
 |---|---|---|---|
 | **.NET Runtime** | 10.0 | Latest 10.0+ | Required |
-| **Windows** | 10 | 11 | âœ… Fully Tested |
-| **Linux** | Ubuntu 20.04+ | Ubuntu 22.04+ | âš ï¸ Untested |
-| **macOS** | 10.15+ | Latest | âš ï¸ Untested |
+| **Windows** | 10 | 11 | Ã¢Å“â€¦ Fully Tested |
+| **Linux** | Ubuntu 20.04+ | Ubuntu 22.04+ | Ã¢Å¡Â Ã¯Â¸Â Untested |
+| **macOS** | 10.15+ | Latest | Ã¢Å¡Â Ã¯Â¸Â Untested |
 
 ### Development Requirements
 
@@ -121,7 +121,7 @@ Both commands should complete **without errors**. If you see errors, check the t
 #### Step 1: Create New Project
 
 1. Open **Visual Studio 2022**
-2. Click **File** â†’ **New** â†’ **Project**
+2. Click **File** Ã¢â€ â€™ **New** Ã¢â€ â€™ **Project**
 3. Search for **"Console App"** (.NET)
 4. Select **"Console App"** template
 5. Click **Next**
@@ -161,12 +161,12 @@ Visual Studio will:
 #### Step 5: Verify Installation
 
 After installation completes:
-1. Right-click **Project** â†’ **Build Project**
+1. Right-click **Project** Ã¢â€ â€™ **Build Project**
 2. Check **Output** window for build success
 3. Look for message: **"Build succeeded"**
 
 **Common Issues During Installation:**
-- If NuGet fails to restore, try: **Tools** â†’ **Options** â†’ **NuGet Package Manager** â†’ **Clear All NuGet Cache(s)**
+- If NuGet fails to restore, try: **Tools** Ã¢â€ â€™ **Options** Ã¢â€ â€™ **NuGet Package Manager** Ã¢â€ â€™ **Clear All NuGet Cache(s)**
 - If build fails, ensure you selected **.NET 10.0** framework in Step 3
 
 ---
@@ -220,7 +220,7 @@ Edit `MyDesktopApp.csproj` to use Razor SDK:
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.2" />
   </ItemGroup>
 </Project>
 ```
@@ -260,10 +260,10 @@ When you run `dotnet add package CheapAvaloniaBlazor`, you get:
 
 ```
 C:\Users\...\MyDesktopApp\.nuget\packages
-â”œâ”€â”€ avalonia/               (Desktop framework)
-â”œâ”€â”€ mudbla zor/             (UI components)
-â”œâ”€â”€ photino.net/            (WebView hosting)
-â””â”€â”€ [dependencies]/         (Supporting packages)
+Ã¢â€Å“Ã¢â€â‚¬Ã¢â€â‚¬ avalonia/               (Desktop framework)
+Ã¢â€Å“Ã¢â€â‚¬Ã¢â€â‚¬ mudbla zor/             (UI components)
+Ã¢â€Å“Ã¢â€â‚¬Ã¢â€â‚¬ photino.net/            (WebView hosting)
+Ã¢â€â€Ã¢â€â‚¬Ã¢â€â‚¬ [dependencies]/         (Supporting packages)
 ```
 
 **Total Size:** ~200-300 MB (first installation only, cached for future projects)
@@ -418,7 +418,7 @@ dotnet --version
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.2" />
   </ItemGroup>
 </Project>
 ```
@@ -483,7 +483,7 @@ dotnet build
 
 1. Ensure **.NET 10.0 SDK is installed** (not just Runtime)
 2. Restart Visual Studio completely
-3. Go to **Tools** â†’ **Options** â†’ **Projects and Solutions** â†’ **.NET Core**
+3. Go to **Tools** Ã¢â€ â€™ **Options** Ã¢â€ â€™ **Projects and Solutions** Ã¢â€ â€™ **.NET Core**
 4. Enable experimental features if disabled
 5. Close and reopen Visual Studio
 
@@ -502,7 +502,7 @@ dotnet new console -n MyDesktopApp
 **Solutions:**
 
 **Visual Studio:**
-1. Go to **Debug** â†’ **Edit and Continue**
+1. Go to **Debug** Ã¢â€ â€™ **Edit and Continue**
 2. Enable **"Hot Reload on File Save"**
 3. Ensure project targets .NET 10.0
 4. Restart debugger
@@ -861,10 +861,10 @@ Version 2.0.0 migrates from the legacy Blazor Server pattern to the modern Blazo
 
 #### What Changed Internally
 
-- `AddServerSideBlazor()` â†’ `AddRazorComponents().AddInteractiveServerComponents()`
-- `MapBlazorHub()` + `MapFallbackToPage()` â†’ `MapRazorComponents<App>().AddInteractiveServerRenderMode()`
-- `blazor.server.js` â†’ `blazor.web.js`
-- `_Host.cshtml` (Razor Page) â†’ `App.razor` (Razor component as HTML document root)
+- `AddServerSideBlazor()` Ã¢â€ â€™ `AddRazorComponents().AddInteractiveServerComponents()`
+- `MapBlazorHub()` + `MapFallbackToPage()` Ã¢â€ â€™ `MapRazorComponents<App>().AddInteractiveServerRenderMode()`
+- `blazor.server.js` Ã¢â€ â€™ `blazor.web.js`
+- `_Host.cshtml` (Razor Page) Ã¢â€ â€™ `App.razor` (Razor component as HTML document root)
 - Razor Pages middleware removed entirely
 
 ---

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ dotnet add package CheapAvaloniaBlazor
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.2" />
   </ItemGroup>
 </Project>
 ```

--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ dotnet add package CheapAvaloniaBlazor
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="CheapAvaloniaBlazor" Version="2.1.0" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
   </ItemGroup>
 </Project>
 ```
 
 **2. Replace `Program.cs`:**
 ```csharp
+using CheapAvaloniaBlazor.Extensions;
 using CheapAvaloniaBlazor.Hosting;
 
 namespace MyDesktopApp;

--- a/templates/CheapAvaloniaBlazor.Templates.csproj
+++ b/templates/CheapAvaloniaBlazor.Templates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>CheapAvaloniaBlazor.Templates</PackageId>
-    <Version>2.1.1</Version>
+    <Version>3.1.1</Version>
     <Authors>CheapNud</Authors>
     <Company>CheapLudes</Company>
     <Description>Project templates for CheapAvaloniaBlazor desktop apps. Install with: dotnet new install CheapAvaloniaBlazor.Templates</Description>

--- a/templates/CheapAvaloniaBlazor.Templates.csproj
+++ b/templates/CheapAvaloniaBlazor.Templates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>CheapAvaloniaBlazor.Templates</PackageId>
-    <Version>3.1.1</Version>
+    <Version>3.1.2</Version>
     <Authors>CheapNud</Authors>
     <Company>CheapLudes</Company>
     <Description>Project templates for CheapAvaloniaBlazor desktop apps. Install with: dotnet new install CheapAvaloniaBlazor.Templates</Description>

--- a/templates/content/CheapBlazorApp-Full/CheapBlazorApp.csproj
+++ b/templates/content/CheapBlazorApp-Full/CheapBlazorApp.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CheapAvaloniaBlazor" Version="2.1.1" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/templates/content/CheapBlazorApp-Full/CheapBlazorApp.csproj
+++ b/templates/content/CheapBlazorApp-Full/CheapBlazorApp.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.2" />
   </ItemGroup>
 </Project>

--- a/templates/content/CheapBlazorApp/CheapBlazorApp.csproj
+++ b/templates/content/CheapBlazorApp/CheapBlazorApp.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CheapAvaloniaBlazor" Version="2.1.1" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/templates/content/CheapBlazorApp/CheapBlazorApp.csproj
+++ b/templates/content/CheapBlazorApp/CheapBlazorApp.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.1" />
+    <PackageReference Include="CheapAvaloniaBlazor" Version="3.1.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The templates package was never included in the publish workflow, so it does not exist on NuGet. Also fixes the compile errors and stale versions in the getting started guide.

Closes #38, closes #39, closes #40, closes #41