### PR TITLE
Match blazor.web.js extraction to the app runtime and refresh stale copies

### DIFF
--- a/Build/CheapAvaloniaBlazor.targets
+++ b/Build/CheapAvaloniaBlazor.targets
@@ -12,41 +12,34 @@
   -->
   <Target Name="CopyBlazorFrameworkFilesFromLibrary" AfterTargets="Build" Condition="'$(TargetFramework)' != '' AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '10.0'))">
     <PropertyGroup>
-      <!-- Try to find the internal assets package - match the major.minor version -->
-      <BlazorInternalAssetsPattern>$(NuGetPackageRoot)microsoft.aspnetcore.app.internal.assets/$([System.Text.RegularExpressions.Regex]::Match('$(TargetFrameworkVersion)', '^\d+\.\d+').Value).*/_framework/</BlazorInternalAssetsPattern>
+      <!-- "v11.0" -> "11.0". Scope the cache glob to the app's own framework version: the NuGet
+           cache is machine-global, and an unscoped **-glob copies every cached version with
+           alphabetical-last winning (so a cached 9.x would beat 10.x). Within the same
+           major.minor multiple patches can still match; the runtime extractor's staleness
+           check settles that at startup. Note: TargetFrameworkVersion carries a leading "v",
+           so the regex must not be anchored. -->
+      <_BlazorTfmMajorMinor>$([System.Text.RegularExpressions.Regex]::Match('$(TargetFrameworkVersion)', '\d+\.\d+').Value)</_BlazorTfmMajorMinor>
       <DestinationFrameworkPath>$(OutputPath)wwwroot/_framework/</DestinationFrameworkPath>
     </PropertyGroup>
 
-    <!-- Find the actual path using wildcard -->
     <ItemGroup>
-      <BlazorInternalAssetsDirs Include="$(NuGetPackageRoot)microsoft.aspnetcore.app.internal.assets/*/_framework/" />
-      <BlazorInternalAssetsDirsSorted Include="@(BlazorInternalAssetsDirs)" Condition="$([System.String]::new('%(Identity)').Contains('$([System.Text.RegularExpressions.Regex]::Match($(TargetFrameworkVersion), ^\d+\.\d+).Value)'))" />
-    </ItemGroup>
-
-    <!-- Use the latest matching version's files -->
-    <PropertyGroup>
-      <BlazorAssetsPath>@(BlazorInternalAssetsDirs->Reverse()->GetPathsOfAllDirectoriesAbove())</BlazorAssetsPath>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <BlazorFrameworkFiles Include="$(NuGetPackageRoot)microsoft.aspnetcore.app.internal.assets/**/_framework/blazor.web.js" />
+      <BlazorFrameworkFiles Include="$(NuGetPackageRoot)microsoft.aspnetcore.app.internal.assets/$(_BlazorTfmMajorMinor).*/_framework/blazor.web.js" />
     </ItemGroup>
 
     <Message Text="CheapAvaloniaBlazor: Looking for Blazor framework files..." Importance="normal" Condition="'@(BlazorFrameworkFiles)' != ''" />
     <MakeDir Directories="$(DestinationFrameworkPath)" Condition="'@(BlazorFrameworkFiles)' != ''" />
 
-    <!-- Copy only the first match (latest version) for each file -->
     <Copy SourceFiles="@(BlazorFrameworkFiles)"
           DestinationFolder="$(DestinationFrameworkPath)"
           SkipUnchangedFiles="true"
           Condition="'@(BlazorFrameworkFiles)' != ''" />
 
     <Message Text="CheapAvaloniaBlazor: Copied Blazor framework files to $(DestinationFrameworkPath)" Importance="high" Condition="'@(BlazorFrameworkFiles)' != ''" />
-    <!-- Not a hard failure: UseStaticWebAssets() in EmbeddedBlazorHostService serves blazor.web.js
-         from the NuGet cache at runtime (Development environment). dotnet publish handles it for deployments.
-         This copy is a convenience for running from build output directly. Common cause: dotnet build without restore
-         on a fresh CI runner where Microsoft.AspNetCore.App.Internal.Assets hasn't been restored yet. -->
-    <Warning Text="CheapAvaloniaBlazor: blazor.web.js not found in NuGet cache (Microsoft.AspNetCore.App.Internal.Assets). Run 'dotnet restore' first, or the app will rely on UseStaticWebAssets() to serve it at runtime." Condition="'@(BlazorFrameworkFiles)' == ''" />
+    <!-- Not a hard failure: the runtime BlazorFrameworkExtractor serves blazor.web.js from the
+         NuGet cache at startup. dotnet publish handles it for deployments. This copy is a
+         convenience for running from build output directly. Common causes: dotnet build without
+         restore on a fresh CI runner, or no cached Internal.Assets version matching the app's framework. -->
+    <Warning Text="CheapAvaloniaBlazor: blazor.web.js $(_BlazorTfmMajorMinor).* not found in NuGet cache (Microsoft.AspNetCore.App.Internal.Assets). Run 'dotnet restore' first, or the app will rely on runtime extraction to serve it." Condition="'@(BlazorFrameworkFiles)' == ''" />
   </Target>
 
   <!-- Only create wwwroot if it doesn't exist, no copying -->

--- a/CheapAvaloniaBlazor.Tests/BlazorFrameworkVersionTests.cs
+++ b/CheapAvaloniaBlazor.Tests/BlazorFrameworkVersionTests.cs
@@ -1,0 +1,173 @@
+using System.Xml.Linq;
+using CheapAvaloniaBlazor.Utilities;
+
+namespace CheapAvaloniaBlazor.Tests;
+
+/// <summary>
+/// Pins the blazor.web.js version-selection and staleness behavior.
+///
+/// The NuGet cache is machine-global, so Microsoft.AspNetCore.App.Internal.Assets can hold
+/// versions from unrelated projects. "Highest version wins" hands a net10 app a preview-12
+/// script; an unscoped MSBuild glob lets alphabetical order decide (where "9.x" beats "10.x").
+/// Selection must follow the runtime the app is actually on, and an already-extracted copy
+/// must be refreshed after a .NET update instead of being served forever.
+/// </summary>
+public class BlazorFrameworkVersionTests
+{
+    private static string VersionDir(string version) => Path.Combine("C:", "cache", "internal.assets", version);
+
+    [Fact]
+    public void Selection_prefers_runtime_major_over_higher_version()
+    {
+        var cacheDirs = new[] { VersionDir("10.0.2"), VersionDir("11.0.0-preview.1.26104.118") };
+
+        var ordered = BlazorFrameworkExtractor.OrderVersionDirectories(cacheDirs, preferredMajor: 10);
+
+        Assert.Equal(VersionDir("10.0.2"), ordered[0]);
+    }
+
+    [Fact]
+    public void Selection_picks_highest_patch_within_the_preferred_major()
+    {
+        // String sort would put 10.0.2 after 10.0.10 — semantic comparison must win.
+        var cacheDirs = new[] { VersionDir("10.0.2"), VersionDir("10.0.10"), VersionDir("9.0.11") };
+
+        var ordered = BlazorFrameworkExtractor.OrderVersionDirectories(cacheDirs, preferredMajor: 10);
+
+        Assert.Equal(VersionDir("10.0.10"), ordered[0]);
+    }
+
+    [Fact]
+    public void Selection_falls_back_to_highest_version_when_runtime_major_is_not_cached()
+    {
+        var cacheDirs = new[] { VersionDir("9.0.11"), VersionDir("10.0.2") };
+
+        var ordered = BlazorFrameworkExtractor.OrderVersionDirectories(cacheDirs, preferredMajor: 12);
+
+        Assert.Equal(VersionDir("10.0.2"), ordered[0]);
+    }
+
+    [Fact]
+    public void Selection_drops_directories_that_are_not_versions()
+    {
+        var cacheDirs = new[] { VersionDir("not-a-version"), VersionDir("10.0.2") };
+
+        var ordered = BlazorFrameworkExtractor.OrderVersionDirectories(cacheDirs, preferredMajor: 10);
+
+        Assert.Single(ordered);
+        Assert.Equal(VersionDir("10.0.2"), ordered[0]);
+    }
+
+    [Fact]
+    public void ParseVersion_strips_prerelease_suffix_and_rejects_junk()
+    {
+        Assert.Equal(new Version(11, 0, 0), BlazorFrameworkExtractor.ParseVersion("11.0.0-preview.1.26104.118"));
+        Assert.Equal(new Version(10, 0, 2), BlazorFrameworkExtractor.ParseVersion("10.0.2"));
+        Assert.Null(BlazorFrameworkExtractor.ParseVersion("not-a-version"));
+    }
+
+    [Fact]
+    public void Stale_when_target_is_missing()
+    {
+        using var scratch = new ScratchDir();
+        var sourceFile = scratch.WriteFile("source.js", "fresh content");
+
+        Assert.True(BlazorFrameworkExtractor.IsTargetStale(sourceFile, Path.Combine(scratch.Root, "missing.js")));
+    }
+
+    [Fact]
+    public void Stale_when_lengths_differ()
+    {
+        using var scratch = new ScratchDir();
+        var sourceFile = scratch.WriteFile("source.js", "new framework script, longer than before");
+        var targetFile = scratch.WriteFile("target.js", "old script");
+
+        Assert.True(BlazorFrameworkExtractor.IsTargetStale(sourceFile, targetFile));
+    }
+
+    [Fact]
+    public void Stale_when_source_is_newer_than_target_at_equal_length()
+    {
+        using var scratch = new ScratchDir();
+        var sourceFile = scratch.WriteFile("source.js", "same-length-a");
+        var targetFile = scratch.WriteFile("target.js", "same-length-b");
+        File.SetLastWriteTimeUtc(targetFile, DateTime.UtcNow.AddDays(-30));
+
+        Assert.True(BlazorFrameworkExtractor.IsTargetStale(sourceFile, targetFile));
+    }
+
+    [Fact]
+    public void Not_stale_when_target_matches_length_and_is_as_recent_as_source()
+    {
+        // File.Copy preserves the source timestamp, so an up-to-date extraction compares equal.
+        using var scratch = new ScratchDir();
+        var sourceFile = scratch.WriteFile("source.js", "same-length-a");
+        var targetFile = Path.Combine(scratch.Root, "target.js");
+        File.Copy(sourceFile, targetFile);
+
+        Assert.False(BlazorFrameworkExtractor.IsTargetStale(sourceFile, targetFile));
+    }
+
+    [Fact]
+    public void Build_targets_glob_is_scoped_to_the_apps_framework_version()
+    {
+        // An unscoped ** glob copies every cached version and lets alphabetical order pick the
+        // winner. The glob must be narrowed by the TFM-derived major.minor property.
+        var targetsPath = Path.Combine(FindRepoRoot(), "Build", "CheapAvaloniaBlazor.targets");
+        var targetsDocument = XDocument.Load(targetsPath);
+
+        var frameworkFileIncludes = targetsDocument.Descendants()
+            .Where(element => element.Name.LocalName == "BlazorFrameworkFiles")
+            .Select(element => element.Attribute("Include")?.Value ?? string.Empty)
+            .ToList();
+
+        Assert.NotEmpty(frameworkFileIncludes);
+        Assert.All(frameworkFileIncludes, include =>
+        {
+            Assert.DoesNotContain("**", include);
+            Assert.Contains("$(_BlazorTfmMajorMinor)", include);
+        });
+    }
+
+    [Fact]
+    public void Build_targets_tfm_regex_tolerates_the_leading_v()
+    {
+        // $(TargetFrameworkVersion) is "v11.0" — an anchored ^\d+\.\d+ regex silently matches
+        // nothing and the glob degrades to matching no versions at all.
+        var targetsPath = Path.Combine(FindRepoRoot(), "Build", "CheapAvaloniaBlazor.targets");
+        var targetsText = File.ReadAllText(targetsPath);
+
+        Assert.DoesNotContain(@"'^\d+\.\d+'", targetsText);
+        Assert.Contains(@"'\d+\.\d+'", targetsText);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null && !File.Exists(Path.Combine(current.FullName, "CheapAvaloniaBlazor.csproj")))
+        {
+            current = current.Parent;
+        }
+
+        return current?.FullName
+            ?? throw new InvalidOperationException("Could not locate the repo root (CheapAvaloniaBlazor.csproj) above the test output directory.");
+    }
+
+    /// <summary>Temp directory that cleans itself up after the test.</summary>
+    private sealed class ScratchDir : IDisposable
+    {
+        public string Root { get; } = Directory.CreateTempSubdirectory("cab-tests-").FullName;
+
+        public string WriteFile(string fileName, string fileContent)
+        {
+            var filePath = Path.Combine(Root, fileName);
+            File.WriteAllText(filePath, fileContent);
+            return filePath;
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Root, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/CheapAvaloniaBlazor.Tests/CheapAvaloniaBlazor.Tests.csproj
+++ b/CheapAvaloniaBlazor.Tests/CheapAvaloniaBlazor.Tests.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CheapAvaloniaBlazor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/CheapAvaloniaBlazor.csproj
+++ b/CheapAvaloniaBlazor.csproj
@@ -59,6 +59,10 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="CheapAvaloniaBlazor.Tests" />
+  </ItemGroup>
+
   <!-- The JS bridge is a plain static web asset: the SDK includes wwwroot\*.js as Content and
        packs it under staticwebassets/, served at _content/CheapAvaloniaBlazor/. The EmbeddedResource
        copy (and its runtime extractor) existed only because Build/CheapAvaloniaBlazor.props used to

--- a/Utilities/BlazorFrameworkExtractor.cs
+++ b/Utilities/BlazorFrameworkExtractor.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace CheapAvaloniaBlazor.Utilities;
 
 /// <summary>
@@ -40,18 +38,27 @@ public static class BlazorFrameworkExtractor
             return _extractedPath;
         }
 
-        // Already present on disk (MSBuild target or previous run)
-        if (File.Exists(targetPath))
-        {
-            _extractedPath = targetPath;
-            _extracted = true;
-            logger.LogVerbose("blazor.web.js already exists at: {Path}", targetPath);
-            return targetPath;
-        }
-
         try
         {
             var sourcePath = FindBlazorWebJs(logger);
+
+            // Present on disk (MSBuild target or previous run) and still matching the cache
+            // source — use it. A bare exists-check is not enough: after a .NET update the old
+            // copy would be served forever, so compare against the resolved source first.
+            if (File.Exists(targetPath))
+            {
+                if (sourcePath == null || !IsTargetStale(sourcePath, targetPath))
+                {
+                    _extractedPath = targetPath;
+                    _extracted = true;
+                    logger.LogVerbose("blazor.web.js already exists at: {Path}", targetPath);
+                    return targetPath;
+                }
+
+                logger.LogInformation("blazor.web.js at {Target} is stale compared to {Source} - refreshing",
+                    targetPath, sourcePath);
+            }
+
             if (sourcePath == null)
             {
                 logger.LogError("Could not find blazor.web.js in NuGet cache. " +
@@ -78,6 +85,26 @@ public static class BlazorFrameworkExtractor
     }
 
     /// <summary>
+    /// True when the extracted copy no longer matches the NuGet cache source.
+    /// File.Copy preserves the source timestamp, so an up-to-date copy has the same
+    /// length and an equal-or-newer write time; a freshly restored .NET update has a
+    /// newer write time (and usually a different length) and wins.
+    /// </summary>
+    internal static bool IsTargetStale(string sourcePath, string targetPath)
+    {
+        var sourceInfo = new FileInfo(sourcePath);
+        var targetInfo = new FileInfo(targetPath);
+
+        if (!targetInfo.Exists)
+            return true;
+
+        if (sourceInfo.Length != targetInfo.Length)
+            return true;
+
+        return sourceInfo.LastWriteTimeUtc > targetInfo.LastWriteTimeUtc;
+    }
+
+    /// <summary>
     /// Searches the NuGet package cache for blazor.web.js from the internal assets package.
     /// </summary>
     private static string? FindBlazorWebJs(Services.DiagnosticLogger logger)
@@ -98,14 +125,12 @@ public static class BlazorFrameworkExtractor
             return null;
         }
 
-        // Find the highest version directory that contains blazor.web.js.
-        // Sort by parsed Version (semantic) so 10.0.2 > 9.0.10 — string sort gets this wrong.
-        var versionDirs = Directory.GetDirectories(packageDir)
-            .Select(d => new { Path = d, Version = ParseVersion(System.IO.Path.GetFileName(d)) })
-            .Where(x => x.Version is not null)
-            .OrderByDescending(x => x.Version)
-            .Select(x => x.Path)
-            .ToArray();
+        // Prefer the cache version matching the runtime the app is actually on — the cache is
+        // machine-global, so "highest version" can hand a net10 app a preview-12 script from an
+        // unrelated project. Within the matching major take the highest; only fall back to other
+        // majors when the runtime's own assets aren't restored.
+        var runtimeMajor = Environment.Version.Major;
+        var versionDirs = OrderVersionDirectories(Directory.GetDirectories(packageDir), runtimeMajor);
 
         foreach (var versionDir in versionDirs)
         {
@@ -115,6 +140,13 @@ public static class BlazorFrameworkExtractor
 
             if (File.Exists(candidate))
             {
+                var candidateVersion = ParseVersion(Path.GetFileName(versionDir));
+                if (candidateVersion?.Major != runtimeMajor)
+                {
+                    logger.LogVerbose("No blazor.web.js for runtime major {RuntimeMajor} in cache - falling back to {Version}",
+                        runtimeMajor, Path.GetFileName(versionDir));
+                }
+
                 logger.LogVerbose("Found blazor.web.js at: {Path}", candidate);
                 return candidate;
             }
@@ -125,10 +157,27 @@ public static class BlazorFrameworkExtractor
     }
 
     /// <summary>
+    /// Orders version directories so the preferred (runtime) major comes first, highest version
+    /// within it; non-matching majors follow, highest first, as a fallback. Non-version
+    /// directory names are dropped. Sorts by parsed Version so 10.0.2 > 9.0.10 — string
+    /// sort gets this wrong.
+    /// </summary>
+    internal static IReadOnlyList<string> OrderVersionDirectories(IEnumerable<string> directories, int preferredMajor)
+    {
+        return directories
+            .Select(directory => new { Path = directory, Version = ParseVersion(System.IO.Path.GetFileName(directory)) })
+            .Where(entry => entry.Version is not null)
+            .OrderByDescending(entry => entry.Version!.Major == preferredMajor)
+            .ThenByDescending(entry => entry.Version)
+            .Select(entry => entry.Path)
+            .ToList();
+    }
+
+    /// <summary>
     /// Parses a version string, stripping NuGet pre-release suffixes (e.g. "10.0.2-preview.1" → 10.0.2).
     /// Returns null for non-version directory names.
     /// </summary>
-    private static Version? ParseVersion(string versionString)
+    internal static Version? ParseVersion(string versionString)
     {
         // Strip pre-release suffix: "10.0.2-preview.1" → "10.0.2"
         var dashIndex = versionString.IndexOf('-');


### PR DESCRIPTION
Stacked on #46. The NuGet cache is machine-global, so the extractor's highest-version-wins selection could hand a net10 app a preview-12 blazor.web.js, and the bare exists-check served a stale copy forever after a .NET update. Selection now prefers the cache version matching the app's runtime major (highest within it, others only as a logged fallback) and an existing copy is refreshed when it no longer matches the cache source. The MSBuild copy target gets the same treatment: the unscoped ** glob (alphabetical-last wins, so a cached 9.x beat 10.x) is narrowed to the app's own major.minor, the anchored regex that never matched the leading v in TargetFrameworkVersion is fixed, and the dead BlazorInternalAssetsPattern/BlazorAssetsPath properties are gone. Eleven tests pin the selection order, staleness rules and targets shape. Verified in a consumer with both 10.0.2 and 11.0.0-preview cached: the net11 app gets the 11-preview file byte-for-byte.