### PR TITLE
Flatten template package content layout

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,8 +30,8 @@ _Nothing blocking._
 
 ## Planned
 
-- [ ] (2026-07-02) Templates nupkg nests payload at `content/content/...` (doubled folder) — harmless, `dotnet new install` works, but consider flattening [audit]
-  - Caused by `ContentTargetFolders=content` combining with the repo's `content/` source dir
+- [x] (2026-07-02 → 2026-07-02) Templates nupkg nests payload at `content/content/...` (doubled folder) — harmless, `dotnet new install` works, but consider flattening [audit]
+  - Caused by `ContentTargetFolders=content` combining with the repo's `content/` source dir; fixed with `ContentTargetFolders=.`
 - [x] (2026-06-11 → 2026-07-02) Fix empty favicon.ico (0 bytes) in both template content dirs — regenerate samples/TemplateApp after [bug]
   - `templates/content/CheapBlazorApp/wwwroot/favicon.ico` and `CheapBlazorApp-Full` variant
 - [x] (2026-06-10 → 2026-06-11) Template smoke tests in CI — install packed nupkg, scaffold both templates, build against local source [plan]

--- a/templates/CheapAvaloniaBlazor.Templates.csproj
+++ b/templates/CheapAvaloniaBlazor.Templates.csproj
@@ -17,7 +17,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <ContentTargetFolders>content</ContentTargetFolders>
+    <ContentTargetFolders>.</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <!-- Required: include .template.config directories (dotfiles excluded by default) -->
     <NoDefaultExcludes>true</NoDefaultExcludes>


### PR DESCRIPTION
Templates were packing at content/content/ due to ContentTargetFolders stacking on the repo's content/ dir.