### PR TITLE
Fix Linux first-boot crash and add startup environment checks

### DIFF
--- a/CheapAvaloniaBlazor.Tests/PlatformHelperTests.cs
+++ b/CheapAvaloniaBlazor.Tests/PlatformHelperTests.cs
@@ -1,0 +1,18 @@
+namespace CheapAvaloniaBlazor.Tests;
+
+public class PlatformHelperTests
+{
+    [Fact]
+    public void Linux_startup_issues_are_empty_on_non_linux_platforms()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            // On Linux the probes hit the real system (display, GTK, WebKitGTK, glibc) —
+            // the result depends on the environment, so only assert it never throws.
+            _ = PlatformHelper.GetLinuxStartupIssues();
+            return;
+        }
+
+        Assert.Empty(PlatformHelper.GetLinuxStartupIssues());
+    }
+}

--- a/Docs/features.md
+++ b/Docs/features.md
@@ -117,7 +117,7 @@ await Settings.UpdateSectionAsync<AppSettings>(s => s.IsDarkMode = false);
 await Settings.SetSectionAsync(new AppSettings { IsDarkMode = true });
 ```
 
-Settings are stored at `%LocalAppData%/{appName}/settings.json`. Configure the location with `WithSettingsFolder()` or `WithSettingsFileName()`.
+Settings are stored at `%LocalAppData%/{appName}/settings.json` on Windows and `~/.local/share/{appName}/settings.json` on Linux. Configure the location with `WithSettingsFolder()` or `WithSettingsFileName()`.
 
 ## App Lifecycle Events (v2.1.0)
 Subscribe to native window lifecycle events from Blazor components. Track window state and react to minimize, maximize, restore, and focus changes.

--- a/Hosting/HostBuilder.cs
+++ b/Hosting/HostBuilder.cs
@@ -609,9 +609,17 @@ public class HostBuilder
         }
     }
 
+    private const string SkipStartupChecksEnvVar = "CHEAPBLAZOR_SKIP_STARTUP_CHECKS";
+
     private static void ValidateLinuxEnvironment()
     {
         if (!OperatingSystem.IsLinux()) return;
+
+        // Escape hatch: the probes are heuristics (soname layouts vary across distros) and a
+        // false negative here would block an otherwise-working app. Containers and exotic
+        // setups can bypass the checks entirely.
+        var skipChecks = Environment.GetEnvironmentVariable(SkipStartupChecksEnvVar);
+        if (skipChecks is "1" || string.Equals(skipChecks, "true", StringComparison.OrdinalIgnoreCase)) return;
 
         var issues = PlatformHelper.GetLinuxStartupIssues();
         if (issues.Count == 0) return;
@@ -622,7 +630,8 @@ public class HostBuilder
         }
 
         throw new PlatformNotSupportedException(
-            "The Linux environment is missing components required to start the app: " + string.Join(" ", issues));
+            "The Linux environment is missing components required to start the app: " + string.Join(" ", issues) +
+            $" If this detection is wrong for your system, set {SkipStartupChecksEnvVar}=1 to bypass these checks.");
     }
 
     /// <summary>

--- a/Hosting/HostBuilder.cs
+++ b/Hosting/HostBuilder.cs
@@ -591,6 +591,10 @@ public class HostBuilder
             Utilities.ConsoleHelper.SuppressConsole();
         }
 
+        // Fail fast with actionable messages when the Linux environment can't host a window —
+        // otherwise missing WebKitGTK/GTK/display surfaces as an obscure native crash later.
+        ValidateLinuxEnvironment();
+
         try
         {
             // FIXED: Use traditional Avalonia App structure for proper platform initialization
@@ -603,6 +607,22 @@ public class HostBuilder
             Console.Error.WriteLine($"Fatal error during application startup: {ex}");
             throw;
         }
+    }
+
+    private static void ValidateLinuxEnvironment()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        var issues = PlatformHelper.GetLinuxStartupIssues();
+        if (issues.Count == 0) return;
+
+        foreach (var issue in issues)
+        {
+            Console.Error.WriteLine($"CheapAvaloniaBlazor startup check failed: {issue}");
+        }
+
+        throw new PlatformNotSupportedException(
+            "The Linux environment is missing components required to start the app: " + string.Join(" ", issues));
     }
 
     /// <summary>

--- a/PlatformHelper.cs
+++ b/PlatformHelper.cs
@@ -4,6 +4,67 @@ namespace CheapAvaloniaBlazor;
 
 public static class PlatformHelper
 {
+    private static readonly Version MinimumGlibcVersion = new(2, 38);
+
+    /// <summary>
+    /// Collects fatal environment problems that would prevent the Photino window from
+    /// opening on Linux. Returns an empty list on a healthy system, and always on non-Linux
+    /// platforms. Each entry is a human-readable description including an install hint.
+    /// </summary>
+    public static IReadOnlyList<string> GetLinuxStartupIssues()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return [];
+
+        var issues = new List<string>();
+
+        var display = Environment.GetEnvironmentVariable("DISPLAY");
+        var waylandDisplay = Environment.GetEnvironmentVariable("WAYLAND_DISPLAY");
+        if (string.IsNullOrEmpty(display) && string.IsNullOrEmpty(waylandDisplay))
+        {
+            issues.Add("No display server detected (neither DISPLAY nor WAYLAND_DISPLAY is set). " +
+                "Run inside a desktop session, or use Xvfb for headless environments.");
+        }
+
+        // Probe via the dynamic loader rather than hardcoded paths so distro layout doesn't matter.
+        // The versioned .so.N names are what runtime packages actually install; the bare .so
+        // symlinks only ship with -dev packages.
+        if (!CanLoadAnyNativeLibrary("libgtk-3.so.0", "libgtk-3.so"))
+        {
+            issues.Add("GTK 3 not found (libgtk-3.so.0). Install it with your package manager, " +
+                "e.g. 'sudo apt install libgtk-3-0'.");
+        }
+
+        if (!CanLoadAnyNativeLibrary("libwebkit2gtk-4.1.so.0", "libwebkit2gtk-4.0.so.37"))
+        {
+            issues.Add("WebKitGTK not found (libwebkit2gtk-4.1.so.0). Install it with your package manager, " +
+                "e.g. 'sudo apt install libwebkit2gtk-4.1-0'.");
+        }
+
+        var glibcVersion = GetGlibcVersion();
+        if (glibcVersion is not null && glibcVersion < MinimumGlibcVersion)
+        {
+            issues.Add($"GLIBC {glibcVersion} is older than {MinimumGlibcVersion} required by Photino.Native. " +
+                "Upgrade to a distribution release that ships a newer glibc (e.g. Ubuntu 24.04+, Debian 13+).");
+        }
+
+        return issues;
+    }
+
+    private static bool CanLoadAnyNativeLibrary(params ReadOnlySpan<string> libraryNames)
+    {
+        foreach (var libraryName in libraryNames)
+        {
+            if (NativeLibrary.TryLoad(libraryName, out var libraryHandle))
+            {
+                NativeLibrary.Free(libraryHandle);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static bool IsPhotinoNetSupported()
     {
         try

--- a/Services/PhotinoMessageHandler.cs
+++ b/Services/PhotinoMessageHandler.cs
@@ -82,7 +82,7 @@ public class PhotinoMessageHandler : IDisposable
     {
         if (_window == null) return false;
 
-        var handle = _window.WindowHandle;
+        var handle = _window.GetWindowHandleOrZero();
         return WindowHelper.HideWindow(handle);
     }
 
@@ -95,7 +95,7 @@ public class PhotinoMessageHandler : IDisposable
     {
         if (_window == null) return false;
 
-        var handle = _window.WindowHandle;
+        var handle = _window.GetWindowHandleOrZero();
         return WindowHelper.ShowAndActivateWindow(handle);
     }
 

--- a/Services/WindowService.cs
+++ b/Services/WindowService.cs
@@ -3,6 +3,7 @@ using System.Net;
 using Avalonia.Threading;
 using CheapAvaloniaBlazor.Models;
 using CheapAvaloniaBlazor.Services.Backends;
+using CheapAvaloniaBlazor.Utilities;
 using Microsoft.Extensions.Logging;
 using Photino.NET;
 
@@ -70,7 +71,7 @@ public sealed class WindowService : IWindowService
     internal void RegisterMainWindow(PhotinoWindow photinoWindow)
     {
         _mainPhotinoWindow = photinoWindow;
-        _mainWindowHandle = photinoWindow.WindowHandle;
+        _mainWindowHandle = photinoWindow.GetWindowHandleOrZero();
         _mainWindowReady.TrySetResult();
         _logger.LogInformation("Main window registered with handle {Handle}", _mainWindowHandle);
     }
@@ -402,7 +403,7 @@ public sealed class WindowService : IWindowService
                         // Capture handle when native window is created (fires during WaitForClose → Photino_ctor)
                         childWindow.RegisterWindowCreatedHandler((s, e) =>
                         {
-                            windowInfo.WindowHandle = childWindow.WindowHandle;
+                            windowInfo.WindowHandle = childWindow.GetWindowHandleOrZero();
                             windowInfo.PhotinoWindow = childWindow;
                             handleReady.Set();
                         });
@@ -447,7 +448,9 @@ public sealed class WindowService : IWindowService
             throw;
         }
 
-        if (windowInfo.WindowHandle == IntPtr.Zero)
+        // Only Windows exposes a native handle (Photino limitation) — on other platforms
+        // Zero is expected and the window is driven through its PhotinoWindow reference.
+        if (OperatingSystem.IsWindows() && windowInfo.WindowHandle == IntPtr.Zero)
         {
             _logger.LogError("Child window '{WindowId}' was created but handle is not available", windowId);
             CleanupPartialWindow(windowInfo);

--- a/Utilities/PhotinoWindowExtensions.cs
+++ b/Utilities/PhotinoWindowExtensions.cs
@@ -1,0 +1,17 @@
+using Photino.NET;
+
+namespace CheapAvaloniaBlazor.Utilities;
+
+/// <summary>
+/// Helpers for <see cref="PhotinoWindow"/> platform quirks.
+/// </summary>
+internal static class PhotinoWindowExtensions
+{
+    /// <summary>
+    /// <see cref="PhotinoWindow.WindowHandle"/> throws <see cref="PlatformNotSupportedException"/>
+    /// on anything other than Windows. Returns <see cref="IntPtr.Zero"/> there instead, so callers
+    /// can share one code path and let the handle-consuming Windows backends no-op.
+    /// </summary>
+    public static IntPtr GetWindowHandleOrZero(this PhotinoWindow window)
+        => OperatingSystem.IsWindows() ? window.WindowHandle : IntPtr.Zero;
+}

--- a/Windows/BlazorHostWindow.cs
+++ b/Windows/BlazorHostWindow.cs
@@ -227,7 +227,7 @@ public partial class BlazorHostWindow : Window, IBlazorWindow
         {
             photinoWindow.RegisterWindowCreatedHandler((s, e) =>
             {
-                menuBarService.Initialize(photinoWindow.WindowHandle, _options?.MenuBarItems);
+                menuBarService.Initialize(photinoWindow.GetWindowHandleOrZero(), _options?.MenuBarItems);
             });
         }
 

--- a/samples/DesktopFeatures/Models/AppSettings.cs
+++ b/samples/DesktopFeatures/Models/AppSettings.cs
@@ -2,7 +2,8 @@ namespace DesktopFeatures.Models;
 
 /// <summary>
 /// Application settings that persist between sessions.
-/// Stored as JSON in %LocalAppData%\DesktopFeatures\settings.json
+/// Stored as JSON in %LocalAppData%\DesktopFeatures\settings.json on Windows,
+/// ~/.local/share/DesktopFeatures/settings.json on Linux
 /// </summary>
 public class AppSettings
 {

--- a/samples/DesktopFeatures/Pages/Index.razor
+++ b/samples/DesktopFeatures/Pages/Index.razor
@@ -294,7 +294,7 @@
 
                 <MudAlert Severity="Severity.Info" Dense="true" Class="mt-2">
                     <MudText Typo="Typo.caption">
-                        Key-value API demo. Values persist to %LocalAppData%\DesktopFeatures\settings.json
+                        Key-value API demo. Values persist to settings.json in the local app data folder (%LocalAppData% on Windows, ~/.local/share on Linux)
                     </MudText>
                 </MudAlert>
             </MudStack>

--- a/templates/content/CheapBlazorApp-Full/Models/AppSettings.cs
+++ b/templates/content/CheapBlazorApp-Full/Models/AppSettings.cs
@@ -2,7 +2,8 @@ namespace CheapBlazorApp.Models;
 
 /// <summary>
 /// Application settings that persist between sessions.
-/// Stored as JSON in %LocalAppData%\CheapBlazorApp\settings.json
+/// Stored as JSON in %LocalAppData%\CheapBlazorApp\settings.json on Windows,
+/// ~/.local/share/CheapBlazorApp/settings.json on Linux
 /// </summary>
 public class AppSettings
 {

--- a/templates/content/CheapBlazorApp-Full/Pages/Index.razor
+++ b/templates/content/CheapBlazorApp-Full/Pages/Index.razor
@@ -294,7 +294,7 @@
 
                 <MudAlert Severity="Severity.Info" Dense="true" Class="mt-2">
                     <MudText Typo="Typo.caption">
-                        Key-value API demo. Values persist to %LocalAppData%\CheapBlazorApp\settings.json
+                        Key-value API demo. Values persist to settings.json in the local app data folder (%LocalAppData% on Windows, ~/.local/share on Linux)
                     </MudText>
                 </MudAlert>
             </MudStack>


### PR DESCRIPTION
Photino's WindowHandle throws on non-Windows, so the window-created handlers crashed Linux at launch. Guards all handle reads and adds fail-fast Linux environment validation (display, GTK, WebKitGTK, glibc) with install hints.