### PR TITLE
Add GTK modal backend for Linux

### DIFF
--- a/Services/Backends/IModalBackend.cs
+++ b/Services/Backends/IModalBackend.cs
@@ -13,16 +13,18 @@ internal interface IModalBackend : IDisposable
 
     /// <summary>
     /// Disable the parent window so it cannot receive input while the modal is open.
+    /// The modal window reference is provided because some backends (GTK) need it to
+    /// tell the two windows apart; the Win32 backend ignores it.
     /// </summary>
-    void DisableParentWindow(IntPtr parentHandle);
+    void DisableParentWindow(ModalWindowRef parent, ModalWindowRef modal);
 
     /// <summary>
     /// Re-enable the parent window after the modal is closed.
     /// </summary>
-    void EnableParentWindow(IntPtr parentHandle);
+    void EnableParentWindow(ModalWindowRef parent);
 
     /// <summary>
-    /// Post a close message to a window in a thread-safe manner.
+    /// Request a window close in a thread-safe manner.
     /// </summary>
-    void PostCloseMessage(IntPtr windowHandle);
+    void PostCloseMessage(ModalWindowRef window);
 }

--- a/Services/Backends/LinuxModalBackend.cs
+++ b/Services/Backends/LinuxModalBackend.cs
@@ -24,8 +24,12 @@ internal sealed class LinuxModalBackend : IModalBackend
 
     private readonly ILogger _logger;
 
-    // Widget pointers disabled per parent window. Only touched on the GTK thread
-    // (inside PhotinoWindow.Invoke), so no locking is needed.
+    // Widget pointers disabled per parent window. Only touched on the GTK thread, so no
+    // locking is needed: PhotinoWindow.Invoke runs the callback directly when already on
+    // the window's thread and otherwise dispatches through Photino_Invoke onto the single
+    // GTK main loop — every access is serialized on that one thread.
+    // Entries are removed on enable and the map is cleared in Dispose, so a parent
+    // reference is only retained while its modal is actually open.
     private readonly Dictionary<PhotinoWindow, List<IntPtr>> _disabledByParent = [];
 
     public bool IsSupported => OperatingSystem.IsLinux();

--- a/Services/Backends/LinuxModalBackend.cs
+++ b/Services/Backends/LinuxModalBackend.cs
@@ -1,0 +1,166 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Extensions.Logging;
+
+namespace CheapAvaloniaBlazor.Services.Backends;
+
+/// <summary>
+/// GTK modal backend. Photino does not expose native window pointers on Linux, so windows
+/// are located by title in the process-wide GTK toplevel list — all Photino windows live on
+/// the single in-process GTK main loop. Parent disabling maps to gtk_widget_set_sensitive,
+/// the closest GTK equivalent of Win32 EnableWindow.
+/// </summary>
+[SupportedOSPlatform("linux")]
+internal sealed class LinuxModalBackend : IModalBackend
+{
+    private readonly ILogger _logger;
+
+    public bool IsSupported => true;
+
+    public LinuxModalBackend(ILogger logger)
+    {
+        // [SupportedOSPlatform] is analyzer-only — enforce at runtime too.
+        if (!OperatingSystem.IsLinux())
+            throw new PlatformNotSupportedException("LinuxModalBackend requires Linux.");
+
+        _logger = logger;
+    }
+
+    public void DisableParentWindow(ModalWindowRef parent, ModalWindowRef modal)
+        => SetParentSensitivity(parent, modal, sensitive: false);
+
+    public void EnableParentWindow(ModalWindowRef parent)
+        => SetParentSensitivity(parent, modal: default, sensitive: true);
+
+    public void PostCloseMessage(ModalWindowRef window)
+    {
+        if (window.Window is null) return;
+
+        try
+        {
+            // PhotinoWindow.Close marshals to the GTK main loop via Invoke — safe from any thread.
+            window.Window.Close();
+        }
+        catch (Exception ex)
+        {
+            // Close throws if the native window is not initialized yet or already destroyed.
+            _logger.LogWarning(ex, "Failed to close window via PhotinoWindow.Close");
+        }
+    }
+
+    public void Dispose() { }
+
+    private void SetParentSensitivity(ModalWindowRef parent, ModalWindowRef modal, bool sensitive)
+    {
+        var parentWindow = parent.Window;
+        if (parentWindow is null) return;
+
+        string parentTitle;
+        string? modalTitle;
+        try
+        {
+            // Photino truncates Linux titles to 31 chars on the managed side too,
+            // so the managed title always equals the GTK title.
+            parentTitle = parentWindow.Title;
+            modalTitle = modal.Window?.Title;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read window titles for modal sensitivity change");
+            return;
+        }
+
+        if (!sensitive && parentTitle == modalTitle)
+        {
+            // Titles are the only way to tell Photino's GTK toplevels apart. With identical
+            // titles the parent cannot be distinguished from the modal, so fail open (parent
+            // stays interactive) rather than risk freezing the modal itself.
+            _logger.LogWarning("Modal and parent share the title '{Title}' — parent will not be disabled. " +
+                "Give the modal window a distinct title to get modal behavior on Linux.", parentTitle);
+            return;
+        }
+
+        // All GTK calls must run on the GTK main loop; PhotinoWindow.Invoke schedules onto it.
+        parentWindow.Invoke(() =>
+        {
+            try
+            {
+                var matches = ApplySensitivityByTitle(parentTitle, sensitive);
+                if (matches == 0)
+                {
+                    _logger.LogWarning("No GTK toplevel titled '{Title}' found to {Action}",
+                        parentTitle, sensitive ? "enable" : "disable");
+                }
+                else
+                {
+                    _logger.LogDebug("{Action} {Count} GTK toplevel(s) titled '{Title}' for modal",
+                        sensitive ? "Enabled" : "Disabled", matches, parentTitle);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "GTK sensitivity change failed for '{Title}'", parentTitle);
+            }
+        });
+    }
+
+    private static int ApplySensitivityByTitle(string title, bool sensitive)
+    {
+        var matchCount = 0;
+        var toplevels = gtk_window_list_toplevels();
+        try
+        {
+            for (var node = toplevels; node != IntPtr.Zero;)
+            {
+                var entry = Marshal.PtrToStructure<GListNode>(node);
+                if (entry.Data != IntPtr.Zero)
+                {
+                    var widgetTitle = Marshal.PtrToStringUTF8(gtk_window_get_title(entry.Data));
+                    if (widgetTitle == title)
+                    {
+                        gtk_widget_set_sensitive(entry.Data, sensitive);
+                        matchCount++;
+                    }
+                }
+                node = entry.Next;
+            }
+        }
+        finally
+        {
+            if (toplevels != IntPtr.Zero)
+                g_list_free(toplevels);
+        }
+
+        return matchCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct GListNode
+    {
+        public IntPtr Data;
+        public IntPtr Next;
+        public IntPtr Prev;
+    }
+
+    // ── P/Invoke ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns a newly allocated GList whose elements are borrowed GtkWindow pointers —
+    /// free the list with g_list_free, never the elements.
+    /// </summary>
+    [DllImport("libgtk-3.so.0")]
+    private static extern IntPtr gtk_window_list_toplevels();
+
+    /// <summary>
+    /// Returns a pointer to the window's internal UTF-8 title (borrowed, do not free),
+    /// or NULL when the window has no title.
+    /// </summary>
+    [DllImport("libgtk-3.so.0")]
+    private static extern IntPtr gtk_window_get_title(IntPtr window);
+
+    [DllImport("libgtk-3.so.0")]
+    private static extern void gtk_widget_set_sensitive(IntPtr widget, [MarshalAs(UnmanagedType.Bool)] bool sensitive);
+
+    [DllImport("libglib-2.0.so.0")]
+    private static extern void g_list_free(IntPtr list);
+}

--- a/Services/Backends/LinuxModalBackend.cs
+++ b/Services/Backends/LinuxModalBackend.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Extensions.Logging;
+using Photino.NET;
 
 namespace CheapAvaloniaBlazor.Services.Backends;
 
@@ -9,13 +10,25 @@ namespace CheapAvaloniaBlazor.Services.Backends;
 /// are located by title in the process-wide GTK toplevel list — all Photino windows live on
 /// the single in-process GTK main loop. Parent disabling maps to gtk_widget_set_sensitive,
 /// the closest GTK equivalent of Win32 EnableWindow.
+/// Title matching happens ONLY at disable time; the matched widget pointers are remembered
+/// per parent so re-enabling works even if the parent's title changes while the modal is open.
+/// Known limitation: a parent and modal sharing the same title cannot be told apart — the
+/// parent is left enabled (fail open) in that case.
 /// </summary>
 [SupportedOSPlatform("linux")]
 internal sealed class LinuxModalBackend : IModalBackend
 {
+    // Photino truncates Linux titles to 31 chars natively; its managed setter mirrors that,
+    // but normalize both sides anyway in case a future Photino version diverges.
+    private const int GtkTitleMaxLength = 31;
+
     private readonly ILogger _logger;
 
-    public bool IsSupported => true;
+    // Widget pointers disabled per parent window. Only touched on the GTK thread
+    // (inside PhotinoWindow.Invoke), so no locking is needed.
+    private readonly Dictionary<PhotinoWindow, List<IntPtr>> _disabledByParent = [];
+
+    public bool IsSupported => OperatingSystem.IsLinux();
 
     public LinuxModalBackend(ILogger logger)
     {
@@ -27,10 +40,87 @@ internal sealed class LinuxModalBackend : IModalBackend
     }
 
     public void DisableParentWindow(ModalWindowRef parent, ModalWindowRef modal)
-        => SetParentSensitivity(parent, modal, sensitive: false);
+    {
+        var parentWindow = parent.Window;
+        if (parentWindow is null) return;
+        var modalWindow = modal.Window;
+
+        // All GTK calls (and the title reads) run on the GTK main loop; PhotinoWindow.Invoke
+        // executes synchronously on it, so titles cannot go stale between read and apply.
+        parentWindow.Invoke(() =>
+        {
+            try
+            {
+                var parentTitle = NormalizeTitle(parentWindow.Title);
+                var modalTitle = NormalizeTitle(modalWindow?.Title);
+
+                if (parentTitle == modalTitle)
+                {
+                    // Titles are the only way to tell Photino's GTK toplevels apart. With
+                    // identical titles the parent cannot be distinguished from the modal, so
+                    // fail open (parent stays interactive) rather than risk freezing the modal.
+                    _logger.LogWarning("Modal and parent share the title '{Title}' — parent will not be disabled. " +
+                        "Give the modal window a distinct title to get modal behavior on Linux.", parentTitle);
+                    return;
+                }
+
+                var matches = FindToplevelsByTitle(parentTitle);
+                if (matches.Count == 0)
+                {
+                    _logger.LogWarning("No GTK toplevel titled '{Title}' found to disable", parentTitle);
+                    return;
+                }
+
+                foreach (var widget in matches)
+                {
+                    gtk_widget_set_sensitive(widget, false);
+                }
+
+                // Remember exactly what was disabled — EnableParentWindow re-enables these
+                // pointers instead of re-matching by (possibly changed) title.
+                _disabledByParent[parentWindow] = matches;
+                _logger.LogDebug("Disabled {Count} GTK toplevel(s) titled '{Title}' for modal", matches.Count, parentTitle);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "GTK parent disable failed");
+            }
+        });
+    }
 
     public void EnableParentWindow(ModalWindowRef parent)
-        => SetParentSensitivity(parent, modal: default, sensitive: true);
+    {
+        var parentWindow = parent.Window;
+        if (parentWindow is null) return;
+
+        parentWindow.Invoke(() =>
+        {
+            try
+            {
+                if (!_disabledByParent.Remove(parentWindow, out var disabledWidgets))
+                    return; // nothing was disabled for this parent (e.g. title-collision fail-open)
+
+                // Guard against stale pointers: the parent could have been destroyed via the
+                // window manager while disabled. Only touch widgets that are still toplevels.
+                var liveToplevels = ListToplevels();
+                var enabledCount = 0;
+                foreach (var widget in disabledWidgets)
+                {
+                    if (liveToplevels.Contains(widget))
+                    {
+                        gtk_widget_set_sensitive(widget, true);
+                        enabledCount++;
+                    }
+                }
+
+                _logger.LogDebug("Re-enabled {Count} GTK toplevel(s) after modal", enabledCount);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "GTK parent enable failed");
+            }
+        });
+    }
 
     public void PostCloseMessage(ModalWindowRef window)
     {
@@ -48,65 +138,30 @@ internal sealed class LinuxModalBackend : IModalBackend
         }
     }
 
-    public void Dispose() { }
-
-    private void SetParentSensitivity(ModalWindowRef parent, ModalWindowRef modal, bool sensitive)
+    public void Dispose()
     {
-        var parentWindow = parent.Window;
-        if (parentWindow is null) return;
-
-        string parentTitle;
-        string? modalTitle;
-        try
-        {
-            // Photino truncates Linux titles to 31 chars on the managed side too,
-            // so the managed title always equals the GTK title.
-            parentTitle = parentWindow.Title;
-            modalTitle = modal.Window?.Title;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Could not read window titles for modal sensitivity change");
-            return;
-        }
-
-        if (!sensitive && parentTitle == modalTitle)
-        {
-            // Titles are the only way to tell Photino's GTK toplevels apart. With identical
-            // titles the parent cannot be distinguished from the modal, so fail open (parent
-            // stays interactive) rather than risk freezing the modal itself.
-            _logger.LogWarning("Modal and parent share the title '{Title}' — parent will not be disabled. " +
-                "Give the modal window a distinct title to get modal behavior on Linux.", parentTitle);
-            return;
-        }
-
-        // All GTK calls must run on the GTK main loop; PhotinoWindow.Invoke schedules onto it.
-        parentWindow.Invoke(() =>
-        {
-            try
-            {
-                var matches = ApplySensitivityByTitle(parentTitle, sensitive);
-                if (matches == 0)
-                {
-                    _logger.LogWarning("No GTK toplevel titled '{Title}' found to {Action}",
-                        parentTitle, sensitive ? "enable" : "disable");
-                }
-                else
-                {
-                    _logger.LogDebug("{Action} {Count} GTK toplevel(s) titled '{Title}' for modal",
-                        sensitive ? "Enabled" : "Disabled", matches, parentTitle);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "GTK sensitivity change failed for '{Title}'", parentTitle);
-            }
-        });
+        _disabledByParent.Clear();
     }
 
-    private static int ApplySensitivityByTitle(string title, bool sensitive)
+    private static string? NormalizeTitle(string? title)
+        => title is { Length: > GtkTitleMaxLength } ? title[..GtkTitleMaxLength] : title;
+
+    private static List<IntPtr> FindToplevelsByTitle(string? title)
     {
-        var matchCount = 0;
+        var matches = new List<IntPtr>();
+        foreach (var widget in ListToplevels())
+        {
+            var widgetTitle = NormalizeTitle(Marshal.PtrToStringUTF8(gtk_window_get_title(widget)));
+            if (widgetTitle == title)
+                matches.Add(widget);
+        }
+
+        return matches;
+    }
+
+    private static List<IntPtr> ListToplevels()
+    {
+        var widgets = new List<IntPtr>();
         var toplevels = gtk_window_list_toplevels();
         try
         {
@@ -114,14 +169,7 @@ internal sealed class LinuxModalBackend : IModalBackend
             {
                 var entry = Marshal.PtrToStructure<GListNode>(node);
                 if (entry.Data != IntPtr.Zero)
-                {
-                    var widgetTitle = Marshal.PtrToStringUTF8(gtk_window_get_title(entry.Data));
-                    if (widgetTitle == title)
-                    {
-                        gtk_widget_set_sensitive(entry.Data, sensitive);
-                        matchCount++;
-                    }
-                }
+                    widgets.Add(entry.Data);
                 node = entry.Next;
             }
         }
@@ -131,7 +179,7 @@ internal sealed class LinuxModalBackend : IModalBackend
                 g_list_free(toplevels);
         }
 
-        return matchCount;
+        return widgets;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/Services/Backends/ModalWindowRef.cs
+++ b/Services/Backends/ModalWindowRef.cs
@@ -1,0 +1,17 @@
+using Photino.NET;
+
+namespace CheapAvaloniaBlazor.Services.Backends;
+
+/// <summary>
+/// Platform-neutral reference to a native window for modal operations.
+/// The Windows backend works through <see cref="Handle"/>; Photino does not expose
+/// native window handles on Linux, so the GTK backend works through the
+/// <see cref="Window"/> reference instead.
+/// </summary>
+internal readonly struct ModalWindowRef(IntPtr handle, PhotinoWindow? window)
+{
+    public IntPtr Handle { get; } = handle;
+    public PhotinoWindow? Window { get; } = window;
+
+    public bool IsEmpty => Handle == IntPtr.Zero && Window is null;
+}

--- a/Services/Backends/NullModalBackend.cs
+++ b/Services/Backends/NullModalBackend.cs
@@ -1,18 +1,18 @@
 namespace CheapAvaloniaBlazor.Services.Backends;
 
 /// <summary>
-/// No-op modal backend for platforms where native modal behavior is not available (Linux, macOS).
+/// No-op modal backend for platforms where native modal behavior is not available (macOS).
 /// Windows still open and close, but the parent is not disabled.
 /// </summary>
 internal sealed class NullModalBackend : IModalBackend
 {
     public bool IsSupported => false;
 
-    public void DisableParentWindow(IntPtr parentHandle) { }
+    public void DisableParentWindow(ModalWindowRef parent, ModalWindowRef modal) { }
 
-    public void EnableParentWindow(IntPtr parentHandle) { }
+    public void EnableParentWindow(ModalWindowRef parent) { }
 
-    public void PostCloseMessage(IntPtr windowHandle) { }
+    public void PostCloseMessage(ModalWindowRef window) { }
 
     public void Dispose() { }
 }

--- a/Services/Backends/WindowsModalBackend.cs
+++ b/Services/Backends/WindowsModalBackend.cs
@@ -24,8 +24,9 @@ internal sealed class WindowsModalBackend : IModalBackend
         _logger = logger;
     }
 
-    public void DisableParentWindow(IntPtr parentHandle)
+    public void DisableParentWindow(ModalWindowRef parent, ModalWindowRef modal)
     {
+        var parentHandle = parent.Handle;
         if (parentHandle == IntPtr.Zero) return;
 
         if (!IsWindow(parentHandle))
@@ -44,8 +45,9 @@ internal sealed class WindowsModalBackend : IModalBackend
         _logger.LogDebug("Disabled parent window {Handle} for modal", parentHandle);
     }
 
-    public void EnableParentWindow(IntPtr parentHandle)
+    public void EnableParentWindow(ModalWindowRef parent)
     {
+        var parentHandle = parent.Handle;
         if (parentHandle == IntPtr.Zero) return;
 
         if (!IsWindow(parentHandle))
@@ -67,8 +69,9 @@ internal sealed class WindowsModalBackend : IModalBackend
         _logger.LogDebug("Re-enabled parent window {Handle} after modal", parentHandle);
     }
 
-    public void PostCloseMessage(IntPtr windowHandle)
+    public void PostCloseMessage(ModalWindowRef window)
     {
+        var windowHandle = window.Handle;
         if (windowHandle == IntPtr.Zero) return;
 
         if (!IsWindow(windowHandle))

--- a/Services/WindowService.cs
+++ b/Services/WindowService.cs
@@ -99,10 +99,11 @@ public sealed class WindowService : IWindowService
         var windowId = await CreateWindowCoreAsync(options, isModal: true, modalTcs: tcs, cancellationToken: cancellationToken);
 
         // Disable the parent window to create modal behavior
-        var parentHandle = ResolveParentHandle(options.ParentWindowId);
-        if (parentHandle != IntPtr.Zero)
+        var parentRef = ResolveParentRef(options.ParentWindowId);
+        var modalRef = _windows.TryGetValue(windowId, out var modalInfo) ? modalInfo.ToModalRef() : default;
+        if (!parentRef.IsEmpty)
         {
-            _modalBackend.DisableParentWindow(parentHandle);
+            _modalBackend.DisableParentWindow(parentRef, modalRef);
         }
 
         // Register cancellation to prevent indefinite hang if the child window crashes or
@@ -117,12 +118,13 @@ public sealed class WindowService : IWindowService
 
                     if (_windows.TryGetValue(windowId, out var cancelledWindowInfo))
                     {
-                        var cancelParentHandle = ResolveParentHandle(cancelledWindowInfo.ParentWindowId);
-                        if (cancelParentHandle != IntPtr.Zero)
-                            _modalBackend.EnableParentWindow(cancelParentHandle);
+                        var cancelParentRef = ResolveParentRef(cancelledWindowInfo.ParentWindowId);
+                        if (!cancelParentRef.IsEmpty)
+                            _modalBackend.EnableParentWindow(cancelParentRef);
 
-                        if (cancelledWindowInfo.WindowHandle != IntPtr.Zero)
-                            _modalBackend.PostCloseMessage(cancelledWindowInfo.WindowHandle);
+                        var cancelledRef = cancelledWindowInfo.ToModalRef();
+                        if (!cancelledRef.IsEmpty)
+                            _modalBackend.PostCloseMessage(cancelledRef);
                     }
                 }
             })
@@ -137,9 +139,10 @@ public sealed class WindowService : IWindowService
 
         if (_windows.TryGetValue(windowId, out var windowInfo))
         {
-            if (windowInfo.WindowHandle != IntPtr.Zero)
+            var windowRef = windowInfo.ToModalRef();
+            if (!windowRef.IsEmpty)
             {
-                _modalBackend.PostCloseMessage(windowInfo.WindowHandle);
+                _modalBackend.PostCloseMessage(windowRef);
             }
         }
         else
@@ -155,8 +158,9 @@ public sealed class WindowService : IWindowService
     /// _modalCompletions — CompleteModal, OnChildWindowClosed, and the CancellationToken callback.
     /// ConcurrentDictionary.TryRemove is atomic: exactly ONE path wins and executes the
     /// EnableParentWindow + PostCloseMessage cleanup. Losers get false and no-op.
-    /// Post-removal actions (EnableParent, PostClose) use value-type IntPtr copies and
-    /// WindowsModalBackend guards each call with IsWindow, so stale handles are safe.
+    /// Post-removal actions (EnableParent, PostClose) use value-type window refs and the
+    /// backends guard staleness themselves (IsWindow on Win32, try/catch around
+    /// PhotinoWindow.Close on Linux), so stale refs are safe.
     /// </remarks>
     public void CompleteModal(string windowId, ModalResult result)
     {
@@ -176,16 +180,17 @@ public sealed class WindowService : IWindowService
         // We own the cleanup since we successfully removed the TCS
         if (_windows.TryGetValue(windowId, out var windowInfo))
         {
-            var parentHandle = ResolveParentHandle(windowInfo.ParentWindowId);
-            if (parentHandle != IntPtr.Zero)
+            var parentRef = ResolveParentRef(windowInfo.ParentWindowId);
+            if (!parentRef.IsEmpty)
             {
-                _modalBackend.EnableParentWindow(parentHandle);
+                _modalBackend.EnableParentWindow(parentRef);
             }
 
             // Close the modal window
-            if (windowInfo.WindowHandle != IntPtr.Zero)
+            var windowRef = windowInfo.ToModalRef();
+            if (!windowRef.IsEmpty)
             {
-                _modalBackend.PostCloseMessage(windowInfo.WindowHandle);
+                _modalBackend.PostCloseMessage(windowRef);
             }
         }
 
@@ -243,14 +248,15 @@ public sealed class WindowService : IWindowService
         foreach (var kvp in _windows)
         {
             var windowInfo = kvp.Value;
-            if (windowInfo.WindowHandle != IntPtr.Zero)
+            var windowRef = windowInfo.ToModalRef();
+            if (!windowRef.IsEmpty)
             {
-                _modalBackend.PostCloseMessage(windowInfo.WindowHandle);
+                _modalBackend.PostCloseMessage(windowRef);
                 closedCount++;
             }
             else
             {
-                _logger.LogWarning("WindowService Dispose: window '{WindowId}' has no handle — cannot send WM_CLOSE",
+                _logger.LogWarning("WindowService Dispose: window '{WindowId}' has no handle or window reference — cannot request close",
                     windowInfo.WindowId);
             }
             windowInfo.PhotinoWindow = null;
@@ -481,10 +487,10 @@ public sealed class WindowService : IWindowService
             // We own the cleanup since we successfully removed the TCS
             if (_windows.TryGetValue(windowId, out var modalWindowInfo))
             {
-                var parentHandle = ResolveParentHandle(modalWindowInfo.ParentWindowId);
-                if (parentHandle != IntPtr.Zero)
+                var parentRef = ResolveParentRef(modalWindowInfo.ParentWindowId);
+                if (!parentRef.IsEmpty)
                 {
-                    _modalBackend.EnableParentWindow(parentHandle);
+                    _modalBackend.EnableParentWindow(parentRef);
                 }
             }
         }
@@ -514,11 +520,12 @@ public sealed class WindowService : IWindowService
     /// </summary>
     private void CleanupPartialWindow(WindowInfo windowInfo)
     {
-        if (windowInfo.WindowHandle != IntPtr.Zero)
+        var windowRef = windowInfo.ToModalRef();
+        if (!windowRef.IsEmpty)
         {
             _logger.LogDebug("Cleaning up partially-created window '{WindowId}' (handle={Handle})",
                 windowInfo.WindowId, windowInfo.WindowHandle);
-            _modalBackend.PostCloseMessage(windowInfo.WindowHandle);
+            _modalBackend.PostCloseMessage(windowRef);
         }
         windowInfo.PhotinoWindow = null;
     }
@@ -557,20 +564,20 @@ public sealed class WindowService : IWindowService
         return $"{baseUrl}/?{Constants.Window.WindowIdQueryParam}={Uri.EscapeDataString(windowId)}";
     }
 
-    private IntPtr ResolveParentHandle(string? parentWindowId)
+    private ModalWindowRef ResolveParentRef(string? parentWindowId)
     {
         if (string.IsNullOrEmpty(parentWindowId) || parentWindowId == Constants.Window.MainWindowId)
         {
-            return _mainWindowHandle;
+            return new ModalWindowRef(_mainWindowHandle, _mainPhotinoWindow);
         }
 
         if (_windows.TryGetValue(parentWindowId, out var parentInfo))
         {
-            return parentInfo.WindowHandle;
+            return parentInfo.ToModalRef();
         }
 
         _logger.LogWarning("Parent window '{ParentWindowId}' not found, falling back to main window", parentWindowId);
-        return _mainWindowHandle;
+        return new ModalWindowRef(_mainWindowHandle, _mainPhotinoWindow);
     }
 
     /// <summary>
@@ -612,6 +619,9 @@ public sealed class WindowService : IWindowService
         if (OperatingSystem.IsWindows())
             return new WindowsModalBackend(logger);
 
+        if (OperatingSystem.IsLinux())
+            return new LinuxModalBackend(logger);
+
         return new NullModalBackend();
     }
 
@@ -624,5 +634,7 @@ public sealed class WindowService : IWindowService
         public PhotinoWindow? PhotinoWindow { get; set; }
         public bool IsModal { get; set; }
         public string? ParentWindowId { get; set; }
+
+        public ModalWindowRef ToModalRef() => new(WindowHandle, PhotinoWindow);
     }
 }

--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,8 @@ _Nothing blocking._
 - [ ] (2026-02-08) Linux hotkey testing: verify D-Bus → X11 fallback chain [plan]
 - [ ] (2026-02-08) Linux GTK menu bar integration [plan]
 - [ ] (2026-02-08) macOS native menu bar integration [plan]
-- [ ] (2026-02-08) Linux/macOS modal behavior (GTK/Cocoa parent disable) [plan]
+- [ ] (2026-02-08) macOS modal behavior (Cocoa parent disable) [plan]
+  - Linux GTK parent disable landed 2026-07-07 (LinuxModalBackend, title-matched toplevels — needs desktop validation)
 - [ ] (2026-02-08) Window positioning relative to parent (center-on-parent calculation) [plan]
 - [ ] (2026-02-08) File path extraction via native backend (Win32 IDropTarget / DragAcceptFiles) [plan]
 


### PR DESCRIPTION
Stacked on #55. Modal windows on Linux now disable their parent via gtk_widget_set_sensitive and close programmatically through PhotinoWindow.Close. The backend interface passes a window ref instead of a raw handle since Photino has no handles on Linux.